### PR TITLE
Update Rakefile

### DIFF
--- a/demo/example1/Rakefile
+++ b/demo/example1/Rakefile
@@ -2,6 +2,6 @@ require "buildtasks"
 
 BuildTasks::GitBuildpackage.define do
   name    "periodicnoise"
-  version "debian/1.1"
+  version "debian/1.2"
   source  "https://github.com/Jimdo/periodicnoise"
 end


### PR DESCRIPTION
Version 1.1 still includes pointers to (the nonexistent) code.google.com which breaks the build job.
